### PR TITLE
feat: add per-source case aggregation timings for latency breakdown

### DIFF
--- a/src/Dfe.CaseAggregationService.Application/Cases/Queries/GetCasesForUser/GetCasesForUser.cs
+++ b/src/Dfe.CaseAggregationService.Application/Cases/Queries/GetCasesForUser/GetCasesForUser.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Diagnostics;
 using Dfe.CaseAggregationService.Application.Common.Models;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -38,6 +39,7 @@ namespace Dfe.CaseAggregationService.Application.Cases.Queries.GetCasesForUser
         ILogger<GetCasesForUserQueryHandler> logger)
         : IRequestHandler<GetCasesForUserQuery, Result<GetCasesByUserResponseModel>>
     {
+        private const string StageTimingsEventName = "CaseAggregation.GetCasesForUser.StageTimings";
 
         public async Task<Result<GetCasesByUserResponseModel>> Handle(GetCasesForUserQuery request,
             CancellationToken cancellationToken)
@@ -47,7 +49,8 @@ namespace Dfe.CaseAggregationService.Application.Cases.Queries.GetCasesForUser
             var userCaseInfo = new List<UserCaseInfo>();
 
             var listOfTasks = new List<Task<IEnumerable<UserCaseInfo>>>();
-            
+
+            var integrationsStopwatch = Stopwatch.StartNew();
             try
             {
                 listOfTasks.AddRange(integrations.Select(x => x.GetCasesForQuery(request, cancellationToken)));
@@ -57,20 +60,56 @@ namespace Dfe.CaseAggregationService.Application.Cases.Queries.GetCasesForUser
             {
                 logger.LogWarning("A call has failed when aggregating cases: {0}", e.Message);
             }
+            integrationsStopwatch.Stop();
 
-            listOfTasks.ForEach(x => userCaseInfo.AddRange(x.Result));
+            foreach (var task in listOfTasks)
+            {
+                if (task.IsCompletedSuccessfully)
+                    userCaseInfo.AddRange(task.Result);
+            }
 
             var returnModel = new GetCasesByUserResponseModel
             {
                 TotalRecordCount = userCaseInfo.Count
             };
 
+            var sortAndPaginationStopwatch = Stopwatch.StartNew();
             SortOutput(request, userCaseInfo);
-
             returnModel.CaseInfos = userCaseInfo.Skip((request.Page - 1) * request.RecordCount).Take(request.RecordCount).ToList();
+            sortAndPaginationStopwatch.Stop();
+
+            EmitStageTimings(
+                integrationsStopwatch.Elapsed.TotalMilliseconds,
+                sortAndPaginationStopwatch.Elapsed.TotalMilliseconds,
+                returnModel.TotalRecordCount,
+                returnModel.CaseInfos.Count);
 
             return Result<GetCasesByUserResponseModel>.Success(returnModel);
+        }
 
+        private void EmitStageTimings(
+            double integrationsElapsedMs,
+            double sortAndPaginationMs,
+            int totalRecordCount,
+            int pageRecordCount)
+        {
+            using (logger.BeginScope(new Dictionary<string, object>
+            {
+                ["EventName"] = StageTimingsEventName,
+                ["IntegrationsElapsedMs"] = integrationsElapsedMs,
+                ["SortAndPaginationMs"] = sortAndPaginationMs,
+                ["TotalRecordCount"] = totalRecordCount,
+                ["PageRecordCount"] = pageRecordCount
+            }))
+            {
+                logger.LogInformation(
+                    "{EventName}: IntegrationsElapsedMs={IntegrationsElapsedMs}, SortAndPaginationMs={SortAndPaginationMs}, TotalRecordCount={TotalRecordCount}, PageRecordCount={PageRecordCount}",
+                    StageTimingsEventName,
+                    integrationsElapsedMs,
+                    sortAndPaginationMs,
+                    totalRecordCount,
+                    pageRecordCount);
+            }
         }
 
         private static void SortOutput(GetCasesForUserQuery request, List<UserCaseInfo> userCaseInfo)

--- a/src/Dfe.CaseAggregationService.Application/Services/SystemIntegration/AcademisationIntegration.cs
+++ b/src/Dfe.CaseAggregationService.Application/Services/SystemIntegration/AcademisationIntegration.cs
@@ -2,7 +2,6 @@
 using Dfe.CaseAggregationService.Application.Common.Models;
 using Dfe.CaseAggregationService.Application.Services.Builders;
 using Dfe.CaseAggregationService.Domain.Entities.Academisation;
-
 using Dfe.CaseAggregationService.Domain.Interfaces.Repositories;
 using Microsoft.Extensions.Logging;
 
@@ -22,13 +21,14 @@ namespace Dfe.CaseAggregationService.Application.Services.SystemIntegration
                 bool includeTransfers = query.FilterProjectTypes?.Contains("Transfer") ?? false;
                 bool includeFormAMat = query.FilterProjectTypes?.Contains("Form a MAT") ?? false;
 
-                return repo.GetAcademisationSummaries(query.UserEmail,
-                        includeConversions, includeTransfers, includeFormAMat, query.SearchTerm)
-                    .ContinueWith(ProcessResult, cancellationToken);
+                return TrackAndProcess(
+                    "Academisation",
+                    () => repo.GetAcademisationSummaries(query.UserEmail,
+                        includeConversions, includeTransfers, includeFormAMat, query.SearchTerm),
+                    cancellationToken);
             }
-            
-            return Task.FromResult<IEnumerable<UserCaseInfo>>(new List<UserCaseInfo>());
-        }
 
+            return SkippedResult("Academisation");
+        }
     }
 }

--- a/src/Dfe.CaseAggregationService.Application/Services/SystemIntegration/CompleteIntegration.cs
+++ b/src/Dfe.CaseAggregationService.Application/Services/SystemIntegration/CompleteIntegration.cs
@@ -3,7 +3,6 @@ using Dfe.CaseAggregationService.Application.Common.Models;
 using Dfe.CaseAggregationService.Application.Services.Builders;
 using Dfe.CaseAggregationService.Domain.Entities.Complete;
 using Dfe.CaseAggregationService.Domain.Interfaces.Repositories;
-using MediatR;
 using Microsoft.Extensions.Logging;
 
 namespace Dfe.CaseAggregationService.Application.Services.SystemIntegration
@@ -18,11 +17,13 @@ namespace Dfe.CaseAggregationService.Application.Services.SystemIntegration
         {
             if (query.IncludeComplete)
             {
-                return repo.GetCompleteSummaryForUser(query.UserEmail, query.FilterProjectTypes, cancellationToken)
-                                .ContinueWith(ProcessResult, cancellationToken);
+                return TrackAndProcess(
+                    "Complete",
+                    () => repo.GetCompleteSummaryForUser(query.UserEmail, query.FilterProjectTypes, cancellationToken),
+                    cancellationToken);
             }
 
-            return Task.FromResult<IEnumerable<UserCaseInfo>>(new List<UserCaseInfo>());
+            return SkippedResult("Complete");
         }
     }
 }

--- a/src/Dfe.CaseAggregationService.Application/Services/SystemIntegration/IntegrationWrapper.cs
+++ b/src/Dfe.CaseAggregationService.Application/Services/SystemIntegration/IntegrationWrapper.cs
@@ -1,4 +1,5 @@
-﻿using Dfe.CaseAggregationService.Application.Common.Models;
+﻿using System.Diagnostics;
+using Dfe.CaseAggregationService.Application.Common.Models;
 using Dfe.CaseAggregationService.Application.Services.Builders;
 using Microsoft.Extensions.Logging;
 
@@ -6,18 +7,74 @@ namespace Dfe.CaseAggregationService.Application.Services.SystemIntegration
 {
     public class IntegrationWrapper<T>(IGetCaseInfo<T> mapper, ILogger logger)
     {
-        protected IEnumerable<UserCaseInfo> ProcessResult(Task<IEnumerable<T>> cases)
+        private const string SourceTimingEventName = "CaseAggregation.IntegrationSourceTiming";
+
+        protected async Task<IEnumerable<UserCaseInfo>> TrackAndProcess(
+            string sourceName,
+            Func<Task<IEnumerable<T>>> fetch,
+            CancellationToken cancellationToken)
         {
-            if (!cases.IsFaulted)
+            var stopwatch = Stopwatch.StartNew();
+
+            try
             {
-                var recast = cases.Result.ToList();
-                return recast.Select(mapper.GetCaseInfo);
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var cases = await fetch();
+                var results = cases.Select(mapper.GetCaseInfo).ToList();
+
+                stopwatch.Stop();
+                EmitSourceTiming(sourceName, stopwatch.Elapsed.TotalMilliseconds, results.Count, success: true, skipped: false);
+
+                return results;
             }
+            catch (OperationCanceledException)
+            {
+                stopwatch.Stop();
+                EmitSourceTiming(sourceName, stopwatch.Elapsed.TotalMilliseconds, recordCount: 0, success: false, skipped: false);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                stopwatch.Stop();
+                logger.LogError(ex, ex.Message);
+                EmitSourceTiming(sourceName, stopwatch.Elapsed.TotalMilliseconds, recordCount: 0, success: false, skipped: false);
+                return [];
+            }
+        }
 
-            if (cases.Exception is not null)
-                logger.LogError(cases.Exception, cases.Exception.Message);
+        protected Task<IEnumerable<UserCaseInfo>> SkippedResult(string sourceName)
+        {
+            EmitSourceTiming(sourceName, elapsedMs: 0, recordCount: 0, success: true, skipped: true);
+            return Task.FromResult<IEnumerable<UserCaseInfo>>([]);
+        }
 
-            return [];
+        private void EmitSourceTiming(
+            string sourceName,
+            double elapsedMs,
+            int recordCount,
+            bool success,
+            bool skipped)
+        {
+            using (logger.BeginScope(new Dictionary<string, object>
+            {
+                ["EventName"] = SourceTimingEventName,
+                ["Source"] = sourceName,
+                ["ElapsedMs"] = elapsedMs,
+                ["RecordCount"] = recordCount,
+                ["Success"] = success,
+                ["Skipped"] = skipped
+            }))
+            {
+                logger.LogInformation(
+                    "{EventName}: Source={Source}, ElapsedMs={ElapsedMs}, RecordCount={RecordCount}, Success={Success}, Skipped={Skipped}",
+                    SourceTimingEventName,
+                    sourceName,
+                    elapsedMs,
+                    recordCount,
+                    success,
+                    skipped);
+            }
         }
     }
 }

--- a/src/Dfe.CaseAggregationService.Application/Services/SystemIntegration/MfspIntegration.cs
+++ b/src/Dfe.CaseAggregationService.Application/Services/SystemIntegration/MfspIntegration.cs
@@ -17,11 +17,13 @@ namespace Dfe.CaseAggregationService.Application.Services.SystemIntegration
         {
             if (query.IncludeManageFreeSchools)
             {
-                return repo.GetMfspSummaries(query.UserEmail, query.FilterProjectTypes)
-                    .ContinueWith(ProcessResult, cancellationToken);
+                return TrackAndProcess(
+                    "Mfsp",
+                    () => repo.GetMfspSummaries(query.UserEmail, query.FilterProjectTypes),
+                    cancellationToken);
             }
 
-            return Task.FromResult<IEnumerable<UserCaseInfo>>(new List<UserCaseInfo>());
+            return SkippedResult("Mfsp");
         }
     }
 }

--- a/src/Dfe.CaseAggregationService.Application/Services/SystemIntegration/RecastIntegration.cs
+++ b/src/Dfe.CaseAggregationService.Application/Services/SystemIntegration/RecastIntegration.cs
@@ -15,14 +15,15 @@ namespace Dfe.CaseAggregationService.Application.Services.SystemIntegration
     {
         public Task<IEnumerable<UserCaseInfo>> GetCasesForQuery(GetCasesForUserQuery query, CancellationToken cancellationToken)
         {
-
             if (query.IncludeConcerns)
             {
-                return repo.GetRecastSummaries(query.UserEmail, query.FilterProjectTypes)
-                    .ContinueWith(ProcessResult, cancellationToken);
+                return TrackAndProcess(
+                    "Recast",
+                    () => repo.GetRecastSummaries(query.UserEmail, query.FilterProjectTypes),
+                    cancellationToken);
             }
 
-            return Task.FromResult<IEnumerable<UserCaseInfo>>(new List<UserCaseInfo>());
+            return SkippedResult("Recast");
         }
     }
 }

--- a/src/Dfe.CaseAggregationService.Application/Services/SystemIntegration/SigChangeIntegration.cs
+++ b/src/Dfe.CaseAggregationService.Application/Services/SystemIntegration/SigChangeIntegration.cs
@@ -15,23 +15,20 @@ namespace Dfe.CaseAggregationService.Application.Services.SystemIntegration
     {
         public Task<IEnumerable<UserCaseInfo>> GetCasesForQuery(GetCasesForUserQuery query, CancellationToken cancellationToken)
         {
-            if(query.FilterProjectTypes != null && query.FilterProjectTypes.Length > 0)
+            if (query.FilterProjectTypes != null && query.FilterProjectTypes.Length > 0)
             {
-                return EmptyResult();
+                return SkippedResult("SigChange");
             }
 
             if (query.IncludeSignificantChange)
             {
-                return repo.GetSigChangeSummaries(query.UserName, query.RecordCount, cancellationToken)
-                    .ContinueWith(ProcessResult, cancellationToken);
+                return TrackAndProcess(
+                    "SigChange",
+                    () => repo.GetSigChangeSummaries(query.UserName, query.RecordCount, cancellationToken),
+                    cancellationToken);
             }
 
-            return EmptyResult();
-        }
-
-        private static Task<IEnumerable<UserCaseInfo>> EmptyResult()
-        {
-            return Task.FromResult<IEnumerable<UserCaseInfo>>(new List<UserCaseInfo>());
+            return SkippedResult("SigChange");
         }
     }
 }


### PR DESCRIPTION
Ticket: https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/System%20Sustainability/Stories?workitem=295193

- Adds per-source timing for each integration (Mfsp, Academisation, Complete, Recast, SigChange): elapsed ms, record count, success/failure, and skipped-when-disabled.
- Adds sort/pagination cost on GetCasesForUser alongside overall integrations wait time.

example query for testing/verifying:

```
traces
| where operation_Id == "<id>"
| where message has "CaseAggregation.IntegrationSourceTiming"
   or message has "CaseAggregation.GetCasesForUser.StageTimings"
| project timestamp, message, customDimensions
```

