### PR TITLE
feat: trim the MFSP summary fetch and filter by project type

### DIFF
--- a/src/Dfe.CaseAggregationService.Infrastructure/Gateways/MfspApiClient.cs
+++ b/src/Dfe.CaseAggregationService.Infrastructure/Gateways/MfspApiClient.cs
@@ -10,6 +10,8 @@ namespace Dfe.CaseAggregationService.Infrastructure.Gateways
 {
     public class MfspApiClient : ApiClient, IMfspRepository
     {
+        private const int SourcePageSize = 100;
+
         public MfspApiClient(
             IHttpClientFactory clientFactory,
             ILogger<ApiClient> logger,
@@ -24,15 +26,23 @@ namespace Dfe.CaseAggregationService.Infrastructure.Gateways
 
             var queryParams = new Dictionary<string, string?>
             {
-                { "projectManagedByEmail", userEmail }
+                { "projectManagedByEmail", userEmail },
+                { "page", "1" },
+                { "count", SourcePageSize.ToString() }
             };
 
             var url = QueryHelpers.AddQueryString(baseUrl, queryParams);
 
             var result = await Get<ApiListWrapper<GetProjectSummaryResponse>>(url);
 
-            var output = result.Data.Where(x => x.ProjectId.Any() &&
-                                                            FilterProjectStatus(x, requestFilterProjectTypes))
+            if (result?.Data is not { Count: > 0 })
+            {
+                return [];
+            }
+
+            var output = result.Data
+                .Where(x => !string.IsNullOrEmpty(x.ProjectId) &&
+                            FilterProjectTypes(x, requestFilterProjectTypes))
                 .Select(x => new MfspSummary()
             {
                 ProjectId = x.ProjectId,
@@ -52,14 +62,14 @@ namespace Dfe.CaseAggregationService.Infrastructure.Gateways
             return output;
         }
 
-        private static bool FilterProjectStatus(GetProjectSummaryResponse response, string[]? filters)
+        private static bool FilterProjectTypes(GetProjectSummaryResponse response, string[]? filters)
         {
-            if (filters is not { Length: > 0})
+            if (filters is not { Length: > 0 })
             {
                 return true;
             }
 
-            return filters is { Length: > 0 } && filters.Contains(response.ProjectStatus);
+            return filters.Contains(response.ProjectType);
         }
 
     }

--- a/src/Tests/Dfe.CaseAggregationService.Api.Tests.Integration/Controllers/CasesControllerTests.cs
+++ b/src/Tests/Dfe.CaseAggregationService.Api.Tests.Integration/Controllers/CasesControllerTests.cs
@@ -103,6 +103,69 @@ namespace Dfe.CaseAggregationService.Api.Tests.Integration.Controllers
 
         [Theory]
         [CustomAutoData(typeof(CustomWebApplicationDbContextFactoryCustomization))]
+        public async Task GetCasesAsync_ShouldMfspCases_WhenFilteredByPresumption(
+            CustomWebApplicationDbContextFactory<Program> factory,
+            ICasesClient caseClient,
+            IFixture fixture)
+        {
+            factory.TestClaims = [new Claim(ClaimTypes.Role, "API.Read")];
+
+            const string? mfspSummarySchoolName = "MfSP School Name";
+
+            SetupMfsp(factory, fixture, mfspSummarySchoolName);
+
+            var result = await caseClient.GetCasesByUserAsync("userName",
+                "userEmail",
+                false,
+                false,
+                false,
+                true,
+                false,
+                false,
+                ["Presumption"],
+                "",
+                null,
+                1,
+                25,
+                "1");
+
+            Assert.NotNull(result);
+            Assert.Equal(1, result.TotalRecordCount);
+            Assert.Equal(mfspSummarySchoolName, result.CaseInfos[0].Title);
+        }
+
+        [Theory]
+        [CustomAutoData(typeof(CustomWebApplicationDbContextFactoryCustomization))]
+        public async Task GetCasesAsync_ShouldExcludeMfspCases_WhenFilteredByCentralRoute(
+            CustomWebApplicationDbContextFactory<Program> factory,
+            ICasesClient caseClient,
+            IFixture fixture)
+        {
+            factory.TestClaims = [new Claim(ClaimTypes.Role, "API.Read")];
+
+            SetupMfsp(factory, fixture, "MfSP School Name");
+
+            var result = await caseClient.GetCasesByUserAsync("userName",
+                "userEmail",
+                false,
+                false,
+                false,
+                true,
+                false,
+                false,
+                ["Central Route"],
+                "",
+                null,
+                1,
+                25,
+                "1");
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.TotalRecordCount);
+        }
+
+        [Theory]
+        [CustomAutoData(typeof(CustomWebApplicationDbContextFactoryCustomization))]
         public async Task GetCasesAsync_ShouldAcademisationCases_WhenCaseExists(
             CustomWebApplicationDbContextFactory<Program> factory,
             ICasesClient caseClient,
@@ -251,6 +314,7 @@ namespace Dfe.CaseAggregationService.Api.Tests.Integration.Controllers
             var mfspSummary = fixture.Create<GetProjectSummaryResponse>();
 
             mfspSummary.ProjectStatus = "Pre-opening";
+            mfspSummary.ProjectType = "Presumption";
             mfspSummary.UpdatedAt = DateTime.UtcNow.AddMonths(2);
             mfspSummary.ProjectTitle = mfspSummarySchoolName;
 
@@ -261,7 +325,12 @@ namespace Dfe.CaseAggregationService.Api.Tests.Integration.Controllers
             };
 
             Assert.NotNull(factory.WireMockServer);
-            factory.WireMockServer.AddGetWithJsonResponse($"/mfsp/api/v1/summary/project", mfspResponse, new List<KeyValuePair<string, string>> { new("projectManagedByEmail", "userEmail") });
+            factory.WireMockServer.AddGetWithJsonResponse($"/mfsp/api/v1/summary/project", mfspResponse, new List<KeyValuePair<string, string>>
+            {
+                new("projectManagedByEmail", "userEmail"),
+                new("page", "1"),
+                new("count", "100")
+            });
         }
 
         private static void SetupPrepare(CustomWebApplicationDbContextFactory<Program> factory, IFixture fixture,

--- a/src/Tests/Dfe.CaseAggregationService.Application.Tests/Services/SystemIntegration/MfspIntegrationTests.cs
+++ b/src/Tests/Dfe.CaseAggregationService.Application.Tests/Services/SystemIntegration/MfspIntegrationTests.cs
@@ -1,0 +1,101 @@
+using AutoFixture;
+using Dfe.CaseAggregationService.Application.Cases.Queries.GetCasesForUser;
+using Dfe.CaseAggregationService.Application.Common.Models;
+using Dfe.CaseAggregationService.Application.Services.Builders;
+using Dfe.CaseAggregationService.Application.Services.SystemIntegration;
+using Dfe.CaseAggregationService.Domain.Entities.Mfsp;
+using Dfe.CaseAggregationService.Domain.Interfaces.Repositories;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Dfe.CaseAggregationService.Application.Tests.Services.SystemIntegration
+{
+    public class MfspIntegrationTests
+    {
+        private readonly Fixture _fixture = new();
+
+        [Fact]
+        public async Task GetCasesForQuery_WhenIncludeManageFreeSchools_ReturnsMappedCases()
+        {
+            var integration = CreateIntegration();
+            var query = new GetCasesForUserQuery(
+                "test user",
+                "test.user@education.gov.uk",
+                false,
+                false,
+                false,
+                true,
+                false,
+                false,
+                []);
+
+            var result = (await integration.GetCasesForQuery(query, CancellationToken.None)).ToArray();
+
+            result.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public async Task GetCasesForQuery_WhenNotIncluded_ReturnsEmpty()
+        {
+            var integration = CreateIntegration();
+            var query = new GetCasesForUserQuery(
+                "test user",
+                "test.user@education.gov.uk",
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                []);
+
+            var result = (await integration.GetCasesForQuery(query, CancellationToken.None)).ToArray();
+
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task GetCasesForQuery_WhenRepositoryFails_ReturnsEmpty()
+        {
+            var integration = CreateIntegration(repoFaulted: true);
+            var query = new GetCasesForUserQuery(
+                "test user",
+                "test.user@education.gov.uk",
+                false,
+                false,
+                false,
+                true,
+                false,
+                false,
+                []);
+
+            var result = (await integration.GetCasesForQuery(query, CancellationToken.None)).ToArray();
+
+            result.Should().BeEmpty();
+        }
+
+        private MfspIntegration CreateIntegration(bool repoFaulted = false)
+        {
+            var repo = Substitute.For<IMfspRepository>();
+            var mapper = Substitute.For<IGetCaseInfo<MfspSummary>>();
+            var logger = Substitute.For<ILogger<MfspIntegration>>();
+
+            if (repoFaulted)
+            {
+                repo.GetMfspSummaries(Arg.Any<string>(), Arg.Any<string[]?>())
+                    .Returns(Task.FromException<IEnumerable<MfspSummary>>(
+                        new HttpRequestException("MFSP unavailable")));
+            }
+            else
+            {
+                repo.GetMfspSummaries(Arg.Any<string>(), Arg.Any<string[]?>())
+                    .Returns([_fixture.Create<MfspSummary>()]);
+            }
+
+            mapper.GetCaseInfo(Arg.Any<MfspSummary>()).Returns(_fixture.Create<UserCaseInfo>());
+
+            return new MfspIntegration(repo, mapper, logger);
+        }
+    }
+}

--- a/src/Tests/Dfe.CaseAggregationService.Infrastructure.Tests/Gateways/MfspApiClientTests.cs
+++ b/src/Tests/Dfe.CaseAggregationService.Infrastructure.Tests/Gateways/MfspApiClientTests.cs
@@ -1,0 +1,135 @@
+using System.Net;
+using System.Text;
+using Dfe.CaseAggregationService.Infrastructure.Dto.Mfsp;
+using Dfe.CaseAggregationService.Infrastructure.Gateways;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using NSubstitute;
+
+namespace Dfe.CaseAggregationService.Infrastructure.Tests.Gateways
+{
+    public class MfspApiClientTests
+    {
+        [Fact]
+        public async Task GetMfspSummaries_RequestsPageOneWithSourceCapOf100()
+        {
+            var handler = new RecordingHandler(Json(Wrap([Summary("T1", "Presumption")])));
+            var client = CreateClient(handler);
+
+            await client.GetMfspSummaries("user@education.gov.uk", null);
+
+            Assert.NotNull(handler.LastRequestUri);
+            Assert.Contains("page=1", handler.LastRequestUri);
+            Assert.Contains("count=100", handler.LastRequestUri);
+            Assert.Contains("projectManagedByEmail=", handler.LastRequestUri);
+            Assert.Contains("user@education.gov.uk", Uri.UnescapeDataString(handler.LastRequestUri));
+        }
+
+        [Fact]
+        public async Task GetMfspSummaries_WhenDataIsNull_ReturnsEmpty()
+        {
+            var client = CreateClient(new RecordingHandler("""{"data":null}"""));
+
+            var result = await client.GetMfspSummaries("user@education.gov.uk", null);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task GetMfspSummaries_WhenDataIsEmpty_ReturnsEmpty()
+        {
+            var client = CreateClient(new RecordingHandler(Json(Wrap([]))));
+
+            var result = await client.GetMfspSummaries("user@education.gov.uk", null);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task GetMfspSummaries_SkipsRowsWithoutProjectId()
+        {
+            var client = CreateClient(new RecordingHandler(Json(Wrap(
+            [
+                Summary(null, "Presumption"),
+                Summary("", "Presumption"),
+                Summary("T3", "Presumption")
+            ]))));
+
+            var result = (await client.GetMfspSummaries("user@education.gov.uk", null)).ToList();
+
+            Assert.Single(result);
+            Assert.Equal("T3", result[0].ProjectId);
+        }
+
+        [Fact]
+        public async Task GetMfspSummaries_WhenFilteredByPresumption_KeepsMatchingType()
+        {
+            var client = CreateClient(new RecordingHandler(Json(Wrap(
+            [
+                Summary("T1", "Presumption"),
+                Summary("T2", "Central Route")
+            ]))));
+
+            var result = (await client.GetMfspSummaries("user@education.gov.uk", ["Presumption"])).ToList();
+
+            Assert.Single(result);
+            Assert.Equal("T1", result[0].ProjectId);
+            Assert.Equal("Presumption", result[0].ProjectType);
+        }
+
+        [Fact]
+        public async Task GetMfspSummaries_WhenFilteredByCentralRoute_ExcludesPresumption()
+        {
+            var client = CreateClient(new RecordingHandler(Json(Wrap([Summary("T1", "Presumption")]))));
+
+            var result = await client.GetMfspSummaries("user@education.gov.uk", ["Central Route"]);
+
+            Assert.Empty(result);
+        }
+
+        private static MfspApiClient CreateClient(RecordingHandler handler)
+        {
+            var httpClient = new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://mfsp.test/")
+            };
+            var factory = Substitute.For<IHttpClientFactory>();
+            factory.CreateClient(Arg.Any<string>()).Returns(httpClient);
+            var logger = Substitute.For<ILogger<ApiClient>>();
+
+            return new MfspApiClient(factory, logger);
+        }
+
+        private static ApiListWrapper<GetProjectSummaryResponse> Wrap(List<GetProjectSummaryResponse> data) =>
+            new() { Data = data, Paging = null };
+
+        private static GetProjectSummaryResponse Summary(string? projectId, string projectType) =>
+            new()
+            {
+                ProjectId = projectId,
+                ProjectType = projectType,
+                ProjectTitle = "School",
+                ProjectStatus = "Pre-opening"
+            };
+
+        private static string Json(object value) => JsonConvert.SerializeObject(value);
+
+        private sealed class RecordingHandler(string json) : HttpMessageHandler
+        {
+            public string? LastRequestUri { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                LastRequestUri = request.RequestUri is { IsAbsoluteUri: true } uri
+                    ? uri.AbsoluteUri
+                    : request.RequestUri?.OriginalString;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ticket: https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/System%20Sustainability/Stories?workitem=295208

- Call MFSP summary with `page=1` and `count=100` (source cap, same idea as Recast/Complete), not the UI page size of 25.
- Filter on `ProjectType` (Presumption / Central Route), not status.
- Treat null/empty MFSP payloads as no cases so a bad response cannot fail the merge.

## Why
Loading every MFSP project was expensive. Capping at the aggregator page size (25) hid cases on later pages and under-counted. **The cases API still returns at most 25 after merge and sort.**

## Test plan
- [ ] `dotnet test` filter `CasesControllerTests`.
- [ ] Cases for a user with MFSP + other systems: still ≤ 25 rows; total is the merged fetch count.
- [ ] Filter Presumption → MFSP presumption cases included; Central Route → those excluded.
- [ ] Page 2 of cases still includes MFSP work when the user has more than 25 cases overall (MFSP contributed up to 100 to the merge).
- [ ] Ship with the [MFSP API PR](https://github.com/DFE-Digital/manage-free-school-projects/pull/1149) so the summary endpoint accepts `page`/`count`.